### PR TITLE
Create all required build directories

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -26,8 +26,7 @@ data['replace']['RELEASE'] = 'Mission'
 cpbo = data['cpbo'];
 
 for directory in [data['BuildDir'], data['PackedDir']+'/Addons', data['PackedDir']+'/Missions']:
-    if not os.path.exists('./Build'):
-        os.mkdir(directory)
+    os.makedirs(directory, exist_ok=True)
 
 for the_file in os.listdir(data['BuildDir']):
     file_path = os.path.join(data['BuildDir'], the_file)


### PR DESCRIPTION
I noticed that `compile.py` would fail on a freshly cloned repository, because not all subdirectories required for the build process were created. I changed the single line in the script to do what was probably the original intention anyway.