### PR TITLE
Re-enable UAV terminal hacking

### DIFF
--- a/Code/Scripts/AT/dronehack_init.sqf
+++ b/Code/Scripts/AT/dronehack_init.sqf
@@ -1,0 +1,17 @@
+call compile preprocessFile "Scripts\AT\hackdrone.sqf";
+
+[] spawn
+{
+    waitUntil {!isNull player};
+	
+	[] spawn at_fnc_dh_init;
+	
+	
+	player addEventHandler 
+	[
+		"Respawn", 
+		{ 
+			[] spawn at_fnc_dh_init;
+		}
+	];
+};

--- a/Code/Scripts/AT/hackdrone.sqf
+++ b/Code/Scripts/AT/hackdrone.sqf
@@ -52,4 +52,3 @@ AT_FNC_dh_Switchmove = {
 	_unit switchmove _anim;	
 
 };
-call at_fnc_dh_init;

--- a/Code/Scripts/AT/hackdrone.sqf
+++ b/Code/Scripts/AT/hackdrone.sqf
@@ -1,0 +1,55 @@
+
+at_fnc_dh_init = {
+	
+	AT_DH_Sides = [east,west,resistance];
+	AT_DH_Terminals = ["O_UavTerminal","B_UavTerminal","I_UavTerminal"];
+	AT_DH_DronesPacked = ["O_UAV_01_backpack_F","B_UAV_01_backpack_F","I_UAV_01_backpack_F"];
+	AT_DH_Drones = ["O_UAV_01_F","B_UAV_01_F","I_UAV_01_F"];
+	
+	player addAction ["Hack UAV Terminal", at_fnc_dh_hackUAVTerminal, [],1,false,true,"", "_this call at_fnc_dh_terminalCheck"];
+};
+
+at_fnc_dh_hackUAVTerminal = {
+	_unit = _this select 1;
+	_side = side _unit;
+	_sideNumber = AT_DH_Sides find _side;
+	if(_sideNumber < 0) exitwith {systemchat "Your side was not found";};
+	_unitItems = (items _unit);
+	{
+		if((_unitItems find _x)!=-1 && _forEachIndex != _sideNumber) exitwith {
+			[[_unit,"AinvPknlMstpSlayWrflDnon_medic"],"at_fnc_dh_switchMove",true] call BIS_fnc_MP;
+			[_unit,_x,(AT_DH_Terminals select _sideNumber)] spawn {
+				sleep 6;
+				if(alive (_this select 0)) then {
+					(_this select 0) removeitem (_this select 1);
+					(_this select 0) additem (_this select 2);
+				};
+			};
+		};
+	} foreach AT_DH_Terminals;
+};
+
+at_fnc_dh_terminalCheck = {
+	_unit = _this;
+	_side = side _unit;
+	_sideNumber = AT_DH_Sides find _side;
+	if(_sideNumber < 0) exitwith {false;};
+	_return = false;
+	_unitItems = (items _unit);
+	{
+		if(_forEachIndex != _sideNumber && _x in _unitItems) exitwith {
+			_return = true;
+		};
+	} foreach AT_DH_Terminals;
+	_return;
+};
+AT_FNC_dh_Switchmove = {
+	private["_unit","_anim"];
+
+	_unit = _this select 0;
+	_anim = _this select 1;
+
+	_unit switchmove _anim;	
+
+};
+call at_fnc_dh_init;

--- a/Code/functions/Common/fn_initLocalPlayer.sqf
+++ b/Code/functions/Common/fn_initLocalPlayer.sqf
@@ -74,6 +74,7 @@ if (isClass(configFile >> "CfgPatches" >> "ACE_Medical")) then {
 	call ATR_FNC_ReviveInit;
 };
 
+call compile preprocessFile "Scripts\AT\dronehack_init.sqf";
 
 setTerrainGrid A3E_Param_Grass;
 


### PR DESCRIPTION
This feature was removed in 8636853b434d3331be37ed839eb56b7a2854f649 due to some issues. But I learned in the meantime that there's actually a [hacking mechanic](https://armedassault.fandom.com/wiki/Hacking_(electronics)) in the game itself, so for the most part it shouldn't be necessary anyway.

The only trouble is that it's impossible to get your hands on a UAV terminal for your own faction, so what we'd need is the ability to convert an enemy UAV terminal into a friendly one. To do that I reintroduced only the necessary portion of the original script and also fixed the issue that caused the player action to appear twice.

I'm not sure if that's the original problem that got this removed, but in any case I won't be disappointed if you decide not to merge this. I'm happy enough to keep it in the patchset for the version that I'm playing, but figured I'll offer it here in case it's useful to others.