### PR TITLE
Add per-server classes support

### DIFF
--- a/Code/functions/Common/fn_checkUnitClasses.sqf
+++ b/Code/functions/Common/fn_checkUnitClasses.sqf
@@ -5,6 +5,7 @@ A3E_Param_UseDLCLaws = 1;
 A3E_Param_NoNightvision = 0;
 A3E_Param_SearchChopper = 2;
 [3] call compile preprocessFileLineNumbers "Units\UnitClasses.sqf";
+call compile preprocessFileLineNumbers "functions\Common\fn_loadLocalClasses.sqf";
 
 private _arraysVehicle = [
     a3e_arr_Escape_StartPositionGuardTypes,

--- a/Code/functions/Common/fn_loadLocalClasses.sqf
+++ b/Code/functions/Common/fn_loadLocalClasses.sqf
@@ -1,0 +1,90 @@
+private _localClasses = profileNamespace getVariable "A3E_Classes";
+if (isNil "_localClasses") exitWith {};
+"parsing local classes" call a3e_fnc_rptLog;
+
+private _allowedArraysNamesLower = [
+    "a3e_arr_Escape_StartPositionGuardTypes",
+    "a3e_arr_PrisonBackpackWeapons",
+    "a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses",
+    "a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses",
+    "a3e_arr_Escape_InfantryTypes",
+    "a3e_arr_Escape_InfantryTypes_Ind",
+    "a3e_arr_recon_InfantryTypes",
+    "a3e_arr_recon_I_InfantryTypes",
+    "a3e_units_civilian_InfantryTypes",
+    "a3e_arr_Escape_RoadBlock_MannedVehicleTypes",
+    "a3e_arr_Escape_RoadBlock_MannedVehicleTypes_Ind",
+    "a3e_arr_Escape_ReinforcementTruck_vehicleClasses",
+    "a3e_arr_Escape_ReinforcementTruck_vehicleClasses_Ind",
+    "a3e_arr_Escape_MotorizedSearchGroup_vehicleClasses",
+    "a3e_arr_ComCenDefence_lightArmorClasses",
+    "a3e_arr_ComCenDefence_heavyArmorClasses",
+    "a3e_arr_ComCenStaticWeapons",
+    "a3e_arr_ComCenParkedVehicles",
+    "a3e_arr_Escape_EnemyCivilianCarTypes",
+    "a3e_arr_Escape_AmmoDepot_StaticWeaponClasses",
+    "a3e_arr_Escape_AmmoDepot_ParkedVehicleClasses",
+    "a3e_arr_O_attack_heli",
+    "a3e_arr_O_transport_heli",
+    "a3e_arr_O_pilots",
+    "a3e_arr_I_transport_heli",
+    "a3e_arr_I_pilots",
+    "a3e_arr_AmmoDepotBasicWeapons",
+    "a3e_arr_AmmoDepotSpecialWeapons",
+    "a3e_arr_AmmoDepotLaunchers",
+    "a3e_arr_AmmoDepotOrdnance",
+    "a3e_arr_AmmoDepotVehicle",
+    "a3e_arr_AmmoDepotVehicleItems",
+    "a3e_arr_AmmoDepotVehicleBackpacks",
+    "a3e_arr_AmmoDepotItems",
+    "a3e_arr_CivilianCarWeapons",
+    "a3e_arr_Scopes",
+    "a3e_arr_Scopes_SMG",
+    "a3e_arr_Scopes_Sniper",
+    "a3e_arr_NightScopes",
+    "a3e_arr_TWSScopes",
+    "a3e_arr_Bipods",
+    "a3e_arr_extraction_chopper",
+    "a3e_arr_extraction_chopper_escort",
+    "a3e_arr_extraction_boat",
+    "a3e_arr_extraction_boat_escort",
+    "a3e_arr_extraction_car",
+    "a3e_arr_extraction_car_escort",
+    "a3e_arr_searchdrone",
+    "a3e_arr_searchChopperEasy",
+    "a3e_arr_searchChopperHard",
+    "a3e_arr_searchChopper_pilot",
+    "a3e_arr_searchChopper_crew",
+    "a3e_arr_AquaticPatrols",
+    "a3e_additional_weapon_box_arsenal_cfgPatches",
+    "a3e_additional_weapon_box_arsenal_weapons",
+    "a3e_arr_MortarSite",
+    "a3e_arr_CASplane",
+    "A3E_Trap_Classes",
+    "A3E_Trap_Pathes"
+] apply {toLower _x};
+
+private _mod = getMissionConfigValue "EscapeMod"; // CUP Desert GER vs Taki Army and Taki Rebels
+private _localClassesHM = createHashMapFromArray _localClasses;
+
+{
+    private _modArrays = _localClassesHM get _x;
+    if (isNil "_modArrays") then {continue};
+
+    format ["found classes %1: %2", _x, _modArrays] call a3e_fnc_rptLog;
+    {
+        _x params ["_arrayName", "_arrayValue"];
+        if (isNil "_arrayName") then {continue};
+        if !(toLower _arrayName in _allowedArraysNamesLower) then {
+            ("found bad array " + _arrayName) call a3e_fnc_rptLog;
+            continue;
+        };
+
+        private _currentArray = missionNamespace getVariable _arrayName;
+        if (isNil "_currentArray") then {
+            missionNamespace setVariable [_arrayName, +_arrayValue];
+        } else {
+            _currentArray append _arrayValue;
+        };
+    } forEach _modArrays;
+} forEach ["global", _mod];

--- a/Code/functions/Server/fn_initServer.sqf
+++ b/Code/functions/Server/fn_initServer.sqf
@@ -25,7 +25,7 @@ if(!isNil("A3E_Param_Debug")) then {
 };
 if(is3DENPreview) then {
 	A3E_Debug = true;
-	
+
 	//Delete AI in Preview:
 	{
 		if(!isPlayer _x) then {
@@ -62,9 +62,10 @@ _enemyFrequency = (A3E_Param_EnemyFrequency);
 _enemySpawnDistance = (A3E_Param_EnemySpawnDistance);
 
 [_enemyFrequency] call compile preprocessFileLineNumbers "Units\UnitClasses.sqf";
+call a3e_fnc_loadLocalClasses;
 
 
-//Load base templates 
+//Load base templates
 [] call a3e_fnc_loadTemplates;
 
 
@@ -87,7 +88,7 @@ A3E_VAR_Side_Ind setFriend [A3E_VAR_Side_Blufor, 0];
 
 A3E_VAR_Side_Blufor setFriend [A3E_VAR_Side_Opfor, 0];
 A3E_VAR_Side_Opfor setFriend [A3E_VAR_Side_Blufor, 0];
-	
+
 if(A3E_Param_War_Torn == 0) then {
 	A3E_VAR_Side_Opfor Setfriend [A3E_VAR_Side_Ind, 1];
 	A3E_VAR_Side_Ind setFriend [A3E_VAR_Side_Opfor, 1];
@@ -103,13 +104,13 @@ if(A3E_Param_War_Torn == 0) then {
 private ["_hour","_date"];
 _hour = A3E_Param_TimeOfDay;
 switch (A3E_Param_TimeOfDay) do {
-    case 24: { 
+    case 24: {
 		_hour = round(random(24));
 	};
     case 25: {
 		_hour = 6+round(random(10));  //Between 0600 and 1600
 	};
-	case 26: { 
+	case 26: {
 		_hour = 17 + round(random(11)); //Between 1700 and 0400
 		_hour = _hour % 24;
 	};
@@ -121,7 +122,7 @@ _date set [4,0];
 
 a3e_var_Escape_hoursSkipped = _hour - (date select 3);
 publicVariable "a3e_var_Escape_hoursSkipped";
-		
+
 [_date] call bis_fnc_setDate;
 
 
@@ -147,18 +148,18 @@ _enemyMaxSkill = 0.60;
 
 //Kudos to Semiconductor
 
-switch (A3E_Param_EnemySkill) do { 
-    // Convert value from params.hpp into acceptable range 
-    case 0: { _enemyMinSkill = 0.10; _enemyMaxSkill = 0.30; }; 
-    case 1: { _enemyMinSkill = 0.30; _enemyMaxSkill = 0.50; }; 
-    case 2: { _enemyMinSkill = 0.40; _enemyMaxSkill = 0.60; }; 
-    case 3: { _enemyMinSkill = 0.60; _enemyMaxSkill = 0.80; }; 
-    case 4: { _enemyMinSkill = 0.80; _enemyMaxSkill = 0.95; }; 
-    default { _enemyMinSkill = 0.40; _enemyMaxSkill = 0.60; }; 
-}; 
+switch (A3E_Param_EnemySkill) do {
+    // Convert value from params.hpp into acceptable range
+    case 0: { _enemyMinSkill = 0.10; _enemyMaxSkill = 0.30; };
+    case 1: { _enemyMinSkill = 0.30; _enemyMaxSkill = 0.50; };
+    case 2: { _enemyMinSkill = 0.40; _enemyMaxSkill = 0.60; };
+    case 3: { _enemyMinSkill = 0.60; _enemyMaxSkill = 0.80; };
+    case 4: { _enemyMinSkill = 0.80; _enemyMaxSkill = 0.95; };
+    default { _enemyMinSkill = 0.40; _enemyMaxSkill = 0.60; };
+};
 
-a3e_var_Escape_enemyMinSkill = _enemyMinSkill; 
-a3e_var_Escape_enemyMaxSkill = _enemyMaxSkill; 
+a3e_var_Escape_enemyMinSkill = _enemyMinSkill;
+a3e_var_Escape_enemyMaxSkill = _enemyMaxSkill;
 a3e_var_Escape_enemyMinSkill = _enemyMinSkill;
 a3e_var_Escape_enemyMaxSkill = _enemyMaxSkill;
 
@@ -201,8 +202,8 @@ private _backpack = [] call A3E_fnc_createStartpos;
 
 //### The following is a mission function now
 
-[true] call A3E_fnc_InitVillageMarkers; 
-//[true] call drn_fnc_InitAquaticPatrolMarkers; 
+[true] call A3E_fnc_InitVillageMarkers;
+//[true] call drn_fnc_InitAquaticPatrolMarkers;
 
 //Wait for players to actually arrive ingame. This may be a long time if server is set to persistent
 waituntil{uisleep 1; count([] call A3E_FNC_GetPlayers)>0};
@@ -253,7 +254,7 @@ if(false) then {
 
     private ["_fnc_OnSpawnAmbientInfantryGroup", "_fnc_OnSpawnAmbientInfantryUnit", "_scriptHandle"];
     private ["_playerGroup", "_minEnemiesPerGroup", "_maxEnemiesPerGroup", "_fnc_OnSpawnGroup"];
-    
+
     _playerGroup = [] call A3E_fnc_GetPlayerGroup;
 
         switch (_enemyFrequency) do
@@ -274,48 +275,48 @@ if(false) then {
                 _maxEnemiesPerGroup = 8;
             };
         };
-        
+
         _fnc_OnSpawnGroup = {
             {
                 _x call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;
             } foreach units _this;
         };
-        
+
         [(units _playerGroup) select 0, A3E_VAR_Side_Opfor, a3e_arr_Escape_InfantryTypes, _minEnemiesPerGroup, _maxEnemiesPerGroup, 500000, _enemyMinSkill, _enemyMaxSkill, _enemySpawnDistance + 250, _fnc_OnSpawnGroup, A3E_Debug] call drn_fnc_InitAquaticPatrols;
 
 
-    
-   
+
+
 
     // Initialize ambient infantry groups
 
 	_fnc_OnSpawnAmbientInfantryUnit = {
 		_this call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;
 	};
-	
+
 	_fnc_OnSpawnAmbientInfantryGroup = {
 		private ["_unit", "_enemyUnit"];
 		private ["_scriptHandle"];
-		
+
 		_unit = units _this select 0;
-		
+
 		while {!(isNull _unit)} do {
 			_enemyUnit = _unit findNearestEnemy (getPos _unit);
 			if (!(isNull _enemyUnit)) exitWith {
-				
+
 				private _i = 0;
 				for [{_i = (count waypoints _this) - 1}, {_i >= 0}, {_i = _i - 1}] do {
 					deleteWaypoint [_this, _i];
 				};
-				
+
 				_scriptHandle = [_this, drn_searchAreaMarkerName, (getPos _enemyUnit), A3E_Debug] spawn drn_fnc_searchGroup;
 				_this setVariable ["drn_scriptHandle", _scriptHandle];
 			};
-			
+
 			sleep 5;
 		};
 	};
-	
+
 	private ["_infantryGroupsCount", "_radius", "_groupsPerSqkm"];
 
 	switch (_enemyFrequency) do
@@ -342,15 +343,15 @@ if(false) then {
 
 	_radius = (_enemySpawnDistance + 500) / 1000;
 	_infantryGroupsCount = round (_groupsPerSqkm * _radius * _radius * 3.141592);
-	
+
 	[_playerGroup, A3E_VAR_Side_Opfor, a3e_arr_Escape_InfantryTypes, _infantryGroupsCount, _enemySpawnDistance + 200, _enemySpawnDistance + 500, _minEnemiesPerGroup, _maxEnemiesPerGroup, _enemyMinSkill, _enemyMaxSkill, 750, _fnc_OnSpawnAmbientInfantryUnit, _fnc_OnSpawnAmbientInfantryGroup, A3E_Debug] spawn drn_fnc_AmbientInfantry;
 
-    
+
     // Initialize the Escape military and civilian traffic
 	private ["_vehiclesPerSqkm", "_radius", "_vehiclesCount", "_fnc_onSpawnCivilian"];
-	
+
 	// Civilian traffic
-	
+
 	switch (_enemyFrequency) do
 	{
 		case 1: // 1-3 players
@@ -366,14 +367,14 @@ if(false) then {
 			_vehiclesPerSqkm = 1.2;
 		};
 	};
-	
+
 	_radius = _enemySpawnDistance + 500;
 	_vehiclesCount = round (_vehiclesPerSqkm * (_radius / 1000) * (_radius / 1000) * 3.141592);
-	
 
-	
+
+
 	// Enemy military traffic
-	
+
 	switch (_enemyFrequency) do
 	{
 		case 1: // 1-3 players
@@ -389,22 +390,22 @@ if(false) then {
 			_vehiclesPerSqkm = 1;
 		};
 	};
-	
+
 	_radius = _enemySpawnDistance + 500;
 	_vehiclesCount = round (_vehiclesPerSqkm * (_radius / 1000) * (_radius / 1000) * 3.141592);
 	[_vehiclesCount,_enemySpawnDistance,_radius,_enemyMinSkill, _enemyMaxSkill] spawn {
 		params["_vehiclesCount","_enemySpawnDistance","_radius","_enemyMinSkill", "_enemyMaxSkill"];
-		sleep 60*15; //Wait 15 Minutes before heavy vehicles may arrive 
+		sleep 60*15; //Wait 15 Minutes before heavy vehicles may arrive
 		[A3E_VAR_Side_Opfor, [], _vehiclesCount/2, _enemySpawnDistance, _radius, _enemyMinSkill, _enemyMaxSkill, drn_fnc_Escape_TrafficSearch, A3E_Debug] spawn drn_fnc_MilitaryTraffic;
 		[A3E_VAR_Side_Ind, [], _vehiclesCount/2, _enemySpawnDistance, _radius, _enemyMinSkill, _enemyMaxSkill, drn_fnc_Escape_TrafficSearch, A3E_Debug] spawn drn_fnc_MilitaryTraffic;
     };
 
 	private ["_areaPerRoadBlock", "_maxEnemySpawnDistanceKm", "_roadBlockCount"];
 	private ["_fnc_OnSpawnInfantryGroup", "_fnc_OnSpawnMannedVehicle"];
-	
+
 	_fnc_OnSpawnInfantryGroup = {{_x call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;} foreach units _this;};
 	_fnc_OnSpawnMannedVehicle = {{_x call drn_fnc_Escape_OnSpawnGeneralSoldierUnit;} foreach (_this select 1);};
-	
+
 	switch (_enemyFrequency) do {
 		case 1: {
 			_areaPerRoadBlock = 4.19;
@@ -416,10 +417,10 @@ if(false) then {
 			_areaPerRoadBlock = 2.5;
 		};
 	};
-	
+
 	_maxEnemySpawnDistanceKm = (_enemySpawnDistance + 500) / 1000;
 	_roadBlockCount = round ((_maxEnemySpawnDistanceKm * _maxEnemySpawnDistanceKm * 3.141592) / _areaPerRoadBlock);
-	
+
 	if (_roadBlockCount < 1) then {
 		_roadBlockCount = 1;
 	};
@@ -459,17 +460,17 @@ call A3E_fnc_InitTraps;
 [A3E_StartPos, _backPack, _enemyFrequency] spawn {
 	params ["_startPos", "_backPack", "_enemyFrequency"];
     private ["_guardGroup", "_marker", "_guardCount", "_guardGroups", "_unit", "_createNewGroup"];
-    
-	 
+
+
     // Spawn guard
 	_guardCount = [-1,-1,3,8] call a3e_fnc_getDynamicSquadSize;
-	private _i = 0;	
+	private _i = 0;
 	for [{_i = 0}, {_i < (_guardCount)}, {_i = _i + 1}] do {
 		private _weapon = a3e_arr_PrisonBackpackWeapons select floor(random(count(a3e_arr_PrisonBackpackWeapons)));
 		_backpack addWeaponCargoGlobal[(_weapon select 0),1];
 		_backpack addMagazineCargoGlobal[(_weapon select 1),3];
 	};
-	
+
     // Spawn more guards
     _marker = createMarker ["drn_guardAreaMarker", _startPos];
     _marker setMarkerShape "ELLIPSE";
@@ -478,62 +479,62 @@ call A3E_fnc_InitTraps;
 	if(missionNamespace getvariable["A3E_Debug",false]) then {
 		_marker setMarkerAlpha 0.5;
 	};
-    
+
     //_guardCount = (2 + (_enemyFrequency)) + floor (random 2);
 
     _guardGroups = [];
     _createNewGroup = true;
-    
+
     for [{_i = 0}, {_i < _guardCount}, {_i = _i + 1}] do {
         private ["_pos"];
-        
+
         _pos = [_marker] call drn_fnc_CL_GetRandomMarkerPos;
         while {_pos distance _startPos < 10} do {
             _pos = [_marker] call drn_fnc_CL_GetRandomMarkerPos;
         };
-        
+
         if (_createNewGroup) then {
             _guardGroup = createGroup A3E_VAR_Side_Ind;
             _guardGroups set [count _guardGroups, _guardGroup];
             _createNewGroup = false;
         };
-        
+
         //(a3e_arr_Escape_StartPositionGuardTypes select floor (random count a3e_arr_Escape_StartPositionGuardTypes)) createUnit [_pos, _guardGroup, "", (0.5), "CAPTAIN"];
         _guardGroup createUnit [(a3e_arr_Escape_StartPositionGuardTypes select floor (random count a3e_arr_Escape_StartPositionGuardTypes)), _pos, [], 0, "FORM"];
-        
+
         if (count units _guardGroup >= 2) then {
             _createNewGroup = true;
         };
     };
-    
+
     {
         _guardGroup = _x;
-        
+
         _guardGroup setFormDir floor (random 360);
-        
+
         {
             _unit = _x; //(units _guardGroup) select 0;
             _unit setUnitRank "CAPTAIN";
             _unit unlinkItem "ItemCompass";
             _unit unlinkItem "ItemGPS";
-			
-			
+
+
 			private _mapItems = missionNamespace getVariable ["A3E_MapItemsUsedInMission",["ItemMap"]];
 			{_unit unlinkItem _x;} foreach _mapItems;
-				
+
 			private _itemsToRemove = missionNamespace getVariable ["A3E_ItemsToBeRemoved",[]];
 			{
 				_unit unlinkItem _x;
 			} foreach _itemsToRemove;
 
-			
-			
+
+
 			if (ACE_MedicalServer) then {_unit addItem "ACE_epinephrine"};//Add Epinephrine for each unit
 			removeBackpackGlobal _unit;
-			
+
 			if(random 100 < 80) then {
 				removeAllPrimaryWeaponItems _unit;
-				
+
 			};
 
 			private _hmd = hmd _unit;
@@ -554,7 +555,7 @@ call A3E_fnc_InitTraps;
 				_unit unlinkItem _hmd;
 				_unit removeItem _hmd;
 			};
-			
+
 			//Track kills
 			_unit addEventHandler ["Killed", {
 				params ["_unit", "_killer"];
@@ -563,21 +564,21 @@ call A3E_fnc_InitTraps;
 					missionNamespace setvariable ["A3E_Kill_Count",_killStats+1,false];
 				};
 			}];
-						
+
             //_unit setSkill a3e_var_Escape_enemyMinSkill;
 			//[_unit, a3e_var_Escape_enemyMinSkill] call EGG_EVO_skill;
-			
+
 			//This should remove all types of handgrenades (for example RHS)
             _unit removeMagazines "Handgrenade";
-            
+
             _unit setVehicleAmmo 0.3 + random 0.7;
 
         } foreach units _guardGroup;
-        
+
         [_guardGroup, _marker] spawn A3E_fnc_Patrol;
-        
+
     } foreach _guardGroups;
-        
+
 	//Add an alert trigger to the prison
 	A3E_fnc_revealPlayers = {
 		private _guardGroup = _this;
@@ -601,9 +602,9 @@ call A3E_fnc_InitTraps;
     // Start thread that waits for escape to start
     [_guardGroups] spawn {
         params ["_guardGroups"];
-        
+
         sleep 5;
-        
+
         while {isNil("A3E_EscapeHasStarted")} do {
 			sleep 1;
             // If any member of the group is to far away from fence, then escape has started
@@ -621,7 +622,7 @@ call A3E_fnc_InitTraps;
 				};
             } foreach call A3E_FNC_GetPlayers;
         };
-        
+
         // ESCAPE HAS STARTED
         //{
 		//	[[[_x], {(_this select 0) setCaptive false;}], "BIS_fnc_spawn", _x, false] call BIS_fnc_MP;
@@ -634,7 +635,7 @@ call A3E_fnc_InitTraps;
 		while{isNil("A3E_SoundPrisonAlarm")} do {
 			if(!isNil("A3E_EscapeHasStarted")) then {
 				{
-					private ["_guardGroup"];					
+					private ["_guardGroup"];
 					_guardGroup = _x;
 					{
 						if((_guardGroup knowsAbout _x)>2.5) exitwith {
@@ -656,7 +657,7 @@ call A3E_fnc_InitTraps;
 			sleep 0.5;
 		};
 	};
-	
+
 	//Watch for captive state
 	[] spawn {
 		while{isNil("A3E_EscapeHasStarted")} do {
@@ -694,4 +695,3 @@ call A3E_fnc_InitTraps;
 		sleep 60;
 	};
 };
-

--- a/Code/include/functions.hpp
+++ b/Code/include/functions.hpp
@@ -30,14 +30,14 @@ class CfgFunctions
 			class GetPlayerGroup {};
 			class CallRandomFunction {};
 			class Briefing {
-			
+
 			//	postInit = 1;
 			};
 			class InitLocalPlayer {
 	#ifndef A3E_EDITOR
 				postInit = 0;
 	#endif
-			};			
+			};
 			class cleanupTerrain {};
 			class handleRating {};
 			class handleScore {};
@@ -46,6 +46,7 @@ class CfgFunctions
 			class initArsenal {};
 			class toggleEarplugs {};
 			class initVillageMarkers {};
+			class loadLocalClasses {};
 		};
 		class AI
 		{
@@ -89,7 +90,7 @@ class CfgFunctions
 			class GetRndBuilding {};
 			class GetRndBuildingPosition {};
 			class GetRndBuildingWithPositions {};
-			
+
 		};
 		class Debug
 		{
@@ -130,7 +131,7 @@ class CfgFunctions
             };
 			class initPlayer {};
 			class watchKnownPosition {};
-			class parameterInit {}; 
+			class parameterInit {};
             class createComCenters {};
             class createMotorPools {};
             class createAmmoDepots {};
@@ -185,7 +186,7 @@ class CfgFunctions
 			class DeactivateZone {};
 			class SerializeZoneGroups {};
 			class DeserializeZoneGroups {};
-			
+
 		};
 		class Templates
 		{
@@ -231,8 +232,8 @@ class CfgFunctions
 			class Roadblock4 {};
 			class Roadblock_VN1 {};
 			class Roadblock_VN2 {};
-			class isoTemplateStore {};		
-			class isoTemplateRestore {};	
+			class isoTemplateStore {};
+			class isoTemplateRestore {};
 			class LoadTemplates {};
 		};
 		class Chronos
@@ -265,15 +266,15 @@ class CfgFunctions
 			class SearchLeaderRadio {};
 			class CreateKnownPosition {};
 			class onPlayerSpotted {};
-			
+
 		};
 	};
 	class drn
 	{
 		class DRN
 		{
-			class AmbientInfantry {}; 
-			class MoveInfantryGroup {}; 
+			class AmbientInfantry {};
+			class MoveInfantryGroup {};
 			class MonitorEmptyGroups {};
 			class PopulateLocation {};
 			class DepopulateLocation {};
@@ -281,7 +282,7 @@ class CfgFunctions
 			class InsertionTruck {};
 			class MilitaryTraffic {};
 			class MoveVehicle {};
-			class MotorizedSearchGroup {};	
+			class MotorizedSearchGroup {};
 			class SearchChopper {};
 			class SearchGroup {};
 			class PopulateAquaticPatrol {};


### PR DESCRIPTION
This PR allows server administrator to add own classes to mission arrays without mission recompiling.
E.g. he wants to add `TGA-200F` civilian scooters for mission with any mod, add `Tigr` and `T-90M` from `[DEV] CUP` to `CUP Woodland USMC vs RU and NAPA` missions, and add `KA-137` UAV to `CUP Woodland RU vs BAF and ION PMC` missions. This configuration can be like this:
```
profileNamespace setVariable ["A3E_Classes", [
    ["CUP Woodland USMC vs RU and NAPA", [
        ["a3e_arr_Escape_MilitaryTraffic_EnemyVehicleClasses", [
            "CUP_O_Tigr_233011_GREEN_RU",
            "CUP_O_Tigr_233014_PK_RU",
            "CUP_O_Tigr_M_233114_RU"
        ]],
        ["a3e_arr_Escape_RoadBlock_MannedVehicleTypes", [
            "CUP_O_Tigr_233014_GREEN_PK_RU",
            "CUP_O_Tigr_M_233114_KORD_RU",
            "CUP_O_Tigr_M_233114_PK_RU"
        ]],
        ["a3e_arr_ComCenDefence_heavyArmorClasses", ["CUP_O_T90M_RU","CUP_O_T90M_RU"]],
    []]],
    ["CUP Woodland RU vs BAF and ION PMC", [
        ["a3e_arr_searchdrone", ["JK_B_ION_KA137_PK_UAV_F"]],
    []]],
    ["global", [
        ["a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses", ["xs_muravei","xs_muravei"]],
        ["a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses", ["xs_muravei2","xs_muravei2"]],
    []]]
]];

saveProfileNamespace;
```
This commands should run once on server. It saves `A3E_Classes` variable to server profile. It's loaded at mission start and all local classes are **added** to mission classes. The variable is persistent across server restarts.

Note `global` section which adds classes to any-mod Escape missions and per-mod sections which add classes only to suitable mod.

Empty class arrays are supported to preserve trailing comma for all arrays (note `[]` at the end of each section). Also arrays with one name can be used to improve formatting (note `a3e_arr_Escape_MilitaryTraffic_CivilianVehicleClasses` arrays in the example).