### PR TITLE
Fix missions with CUP russian desert player units

### DIFF
--- a/Configs/CUP.json
+++ b/Configs/CUP.json
@@ -91,16 +91,16 @@
 				{
 					"MOD" : "CUP Desert RU vs US Army and ION PMC",
 					"PLAYERSIDE" : "EAST",
-					"PLAYERUNIT_1" : "CUP_O_RU_Soldier_SL_Ratnik_BeigeDigital",
-					"PLAYERUNIT_2" : "CUP_O_RU_Soldier_LAT_Ratnik_BeigeDigital",
-					"PLAYERUNIT_3" : "CUP_O_RU_Soldier_AA_Ratnik_BeigeDigital",
-					"PLAYERUNIT_4" : "CUP_O_RU_Soldier_Engineer_Ratnik_BeigeDigital",
-					"PLAYERUNIT_5" : "CUP_O_RU_Soldier_GL_Ratnik_BeigeDigital",
-					"PLAYERUNIT_6" : "CUP_O_RU_Soldier_AR_Ratnik_BeigeDigital",
-					"PLAYERUNIT_7" : "CUP_O_RU_Soldier_AT_Ratnik_BeigeDigital",
-					"PLAYERUNIT_8" : "CUP_O_RU_Soldier_Ratnik_BeigeDigital",
-					"PLAYERUNIT_9" : "CUP_O_RU_Soldier_Marksman_Ratnik_BeigeDigital",
-					"PLAYERUNIT_10" : "CUP_O_RU_Soldier_Medic_Ratnik_BeigeDigital"
+					"PLAYERUNIT_1" : "CUP_O_RUS_M_Soldier_SL_VKPO_Desert",
+					"PLAYERUNIT_2" : "CUP_O_RUS_M_Soldier_LAT_VKPO_Desert",
+					"PLAYERUNIT_3" : "CUP_O_RUS_M_Soldier_AA_VKPO_Desert",
+					"PLAYERUNIT_4" : "CUP_O_RUS_M_Soldier_Engineer_VKPO_Desert",
+					"PLAYERUNIT_5" : "CUP_O_RUS_M_Soldier_GL_VKPO_Desert",
+					"PLAYERUNIT_6" : "CUP_O_RUS_M_Soldier_AR_VKPO_Desert",
+					"PLAYERUNIT_7" : "CUP_O_RUS_M_Soldier_AT_VKPO_Desert",
+					"PLAYERUNIT_8" : "CUP_O_RUS_M_Soldier_VKPO_Desert",
+					"PLAYERUNIT_9" : "CUP_O_RUS_M_Soldier_Marksman_VKPO_Desert",
+					"PLAYERUNIT_10" : "CUP_O_RUS_M_Soldier_Medic_VKPO_Desert"
 				}
 		},
 		{
@@ -111,16 +111,16 @@
 				{
 					"MOD" : "CUP Desert RU vs BAF and ACR",
 					"PLAYERSIDE" : "EAST",
-					"PLAYERUNIT_1" : "CUP_O_RU_Soldier_SL_Ratnik_BeigeDigital",
-					"PLAYERUNIT_2" : "CUP_O_RU_Soldier_LAT_Ratnik_BeigeDigital",
-					"PLAYERUNIT_3" : "CUP_O_RU_Soldier_AA_Ratnik_BeigeDigital",
-					"PLAYERUNIT_4" : "CUP_O_RU_Soldier_Engineer_Ratnik_BeigeDigital",
-					"PLAYERUNIT_5" : "CUP_O_RU_Soldier_GL_Ratnik_BeigeDigital",
-					"PLAYERUNIT_6" : "CUP_O_RU_Soldier_AR_Ratnik_BeigeDigital",
-					"PLAYERUNIT_7" : "CUP_O_RU_Soldier_AT_Ratnik_BeigeDigital",
-					"PLAYERUNIT_8" : "CUP_O_RU_Soldier_Ratnik_BeigeDigital",
-					"PLAYERUNIT_9" : "CUP_O_RU_Soldier_Marksman_Ratnik_BeigeDigital",
-					"PLAYERUNIT_10" : "CUP_O_RU_Soldier_Medic_Ratnik_BeigeDigital"
+					"PLAYERUNIT_1" : "CUP_O_RUS_M_Soldier_SL_VKPO_Desert",
+					"PLAYERUNIT_2" : "CUP_O_RUS_M_Soldier_LAT_VKPO_Desert",
+					"PLAYERUNIT_3" : "CUP_O_RUS_M_Soldier_AA_VKPO_Desert",
+					"PLAYERUNIT_4" : "CUP_O_RUS_M_Soldier_Engineer_VKPO_Desert",
+					"PLAYERUNIT_5" : "CUP_O_RUS_M_Soldier_GL_VKPO_Desert",
+					"PLAYERUNIT_6" : "CUP_O_RUS_M_Soldier_AR_VKPO_Desert",
+					"PLAYERUNIT_7" : "CUP_O_RUS_M_Soldier_AT_VKPO_Desert",
+					"PLAYERUNIT_8" : "CUP_O_RUS_M_Soldier_VKPO_Desert",
+					"PLAYERUNIT_9" : "CUP_O_RUS_M_Soldier_Marksman_VKPO_Desert",
+					"PLAYERUNIT_10" : "CUP_O_RUS_M_Soldier_Medic_VKPO_Desert"
 				}
 		},
 		{
@@ -191,16 +191,16 @@
 				{
 					"MOD" : "CUP Desert RU vs US Army and Taki Rebels",
 					"PLAYERSIDE" : "EAST",
-					"PLAYERUNIT_1" : "CUP_O_RU_Soldier_SL_Ratnik_Desert",
-					"PLAYERUNIT_2" : "CUP_O_RU_Soldier_LAT_Ratnik_Desert",
-					"PLAYERUNIT_3" : "CUP_O_RU_Soldier_AA_Ratnik_Desert",
-					"PLAYERUNIT_4" : "CUP_O_RU_Soldier_Engineer_Ratnik_Desert",
-					"PLAYERUNIT_5" : "CUP_O_RU_Soldier_GL_Ratnik_Desert",
-					"PLAYERUNIT_6" : "CUP_O_RU_Soldier_MG_Ratnik_Desert",
-					"PLAYERUNIT_7" : "CUP_O_RU_Soldier_AT_Ratnik_Desert",
-					"PLAYERUNIT_8" : "CUP_O_RU_Soldier_Ratnik_Desert",
-					"PLAYERUNIT_9" : "CUP_O_RU_Soldier_Marksman_Ratnik_Desert",
-					"PLAYERUNIT_10" : "CUP_O_RU_Soldier_Medic_Ratnik_Desert"
+					"PLAYERUNIT_1" : "CUP_O_RUS_M_Soldier_SL_VKPO_Desert",
+					"PLAYERUNIT_2" : "CUP_O_RUS_M_Soldier_LAT_VKPO_Desert",
+					"PLAYERUNIT_3" : "CUP_O_RUS_M_Soldier_AA_VKPO_Desert",
+					"PLAYERUNIT_4" : "CUP_O_RUS_M_Soldier_Engineer_VKPO_Desert",
+					"PLAYERUNIT_5" : "CUP_O_RUS_M_Soldier_GL_VKPO_Desert",
+					"PLAYERUNIT_6" : "CUP_O_RUS_M_Soldier_AR_VKPO_Desert",
+					"PLAYERUNIT_7" : "CUP_O_RUS_M_Soldier_AT_VKPO_Desert",
+					"PLAYERUNIT_8" : "CUP_O_RUS_M_Soldier_VKPO_Desert",
+					"PLAYERUNIT_9" : "CUP_O_RUS_M_Soldier_Marksman_VKPO_Desert",
+					"PLAYERUNIT_10" : "CUP_O_RUS_M_Soldier_Medic_VKPO_Desert"
 				}
 		},
 		{


### PR DESCRIPTION
Old units are `scope=1` in CUP 1.18 and mission is not loaded.

Credits go to Jugger.